### PR TITLE
Replace target='_blank' function with setting in wp-admin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -242,12 +242,3 @@ function has_submenu($menuitems, $parent_id) {
     }
     return false;
 }
-function add_target_blank_to_social_links( $block_content, $block ) {
-    // Check if the block is a social links block
-    if ( strpos( $block['blockName'], 'core/social-links' ) !== false ) {
-        // Add target="_blank" to all anchor tags in the block content
-        $block_content = str_replace('<a', '<a target="_blank" rel="noopener noreferrer"', $block_content);
-    }
-    return $block_content;
-}
-add_filter('render_block', 'add_target_blank_to_social_links', 10, 2);


### PR DESCRIPTION
The target="_blank" function was not effective when trying to open a social link to another tab. Discovered that there was a built in setting for widgets to enable links to be opened to new tabs, so I removed the function.