### PR TITLE
Setting the projects columns for tablet (2 cols) and desktop (3 cols)…

### DIFF
--- a/template-parts/template-projects.php
+++ b/template-parts/template-projects.php
@@ -83,7 +83,7 @@ $cta_button_link = get_field('cta_button_link');
             $categories_string = esc_attr( implode(' ', $categories) );
             $thumbnail_url = esc_url( wp_get_attachment_url(get_post_thumbnail_id($post_id)) );
             ?>
-            <li class="col-md-4" data-categories="<?php echo $categories_string; ?>">
+            <li class="col-md-6 col-lg-4" data-categories="<?php echo $categories_string; ?>">
               <div class="listing-featured-wrap">
                 <div class="listing-featured-wrap-image" style="background: url(<?php echo $thumbnail_url; ?>) no-repeat top;"></div>
                 <div class="listing-featured-text">


### PR DESCRIPTION
Added bootstrap's default sizing for laptop and tablet views to make the projects more readable.