### PR TITLE
Fixed EST 2009 scroll in template-home.php

### DIFF
--- a/template-parts/template-home.php
+++ b/template-parts/template-home.php
@@ -47,14 +47,14 @@ get_header();
   
   <!--scroll down-->
   <div class="scroll-down-btn" data-aos="fade-up">
-    <a href="#arrowsection"><img src="<?php echo esc_url(get_stylesheet_directory_uri() . '/assets/images/circle.svg'); ?>" alt="circle"></a>
+    <a href="#about-main-wrap"><img src="<?php echo esc_url(get_stylesheet_directory_uri() . '/assets/images/circle.svg'); ?>" alt="circle"></a>
   </div>
   <!--scroll down--> 
   
 </section>
 <!--header slider--> 
 
-<section class="about-main-wrap"> 
+<section class="about-main-wrap" id="about-main-wrap"> 
   <!--about-->
   <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css">
   <div class="container bootstrap snippets bootdey " data-aos="fade-up">


### PR DESCRIPTION
1. Added an id attribute named "about-main-wrap" to the About section, allowing for targeted navigation within the page.
2. Linked this newly added id to the anchor tag associated with the EST 2009 scroll image. This enables smooth scrolling to the About section when the user clicks on the scroll image.