### PR TITLE
next carat button showing on the right

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -98,7 +98,7 @@
   nav: true,
   navText: [
     "<i class='fa fa-angle-left'></i> previous ",
-    "<i class='fa fa-angle-right'></i> next "
+    "next <i class='fa fa-angle-right'></i>"
   ],
   autoplay: true,
   autoplayHoverPause: true,


### PR DESCRIPTION
DWM Homepage In the "What our Clients Say" section, the "NEXT" button carat should be showing on the right side of the word, not the left
[Link](https://app.asana.com/0/599212887649773/1208523055282847/f)