### PR TITLE
Set has_archive to false

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -325,7 +325,7 @@ function create_services_post_type() {
         'public' => true,
         'menu_position' => 5,
         'supports' => array('title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'page-attributes'),
-        'has_archive' => true,
+        'has_archive' => false,
         'rewrite' => array('slug' => 'services'),
         'menu_icon' => 'dashicons-admin-tools', // Optional icon
         'orderby' => 'menu_order',


### PR DESCRIPTION
I set has_archive to false to prevent WordPress from generating an archive page for the 'services' custom post type at the /services/ URL.
https://app.asana.com/0/599212887649773/1208562315891802/f