### PR TITLE
Prevent archive page from popping up for services, make featured projects three columns, and style start button

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -325,7 +325,7 @@ function create_services_post_type() {
         'public' => true,
         'menu_position' => 5,
         'supports' => array('title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'page-attributes'),
-        'has_archive' => true,
+        'has_archive' => false,
         'rewrite' => array('slug' => 'services'),
         'menu_icon' => 'dashicons-admin-tools', // Optional icon
         'orderby' => 'menu_order',

--- a/template-parts/template-home.php
+++ b/template-parts/template-home.php
@@ -292,7 +292,7 @@ get_header();
             while ($query->have_posts()) : $query->the_post(); 
               $thumbnail_url = esc_url(wp_get_attachment_url(get_post_thumbnail_id(get_the_ID())));
               ?>
-              <li class="col-md-6">
+              <li class="col-md-4">
                 <div class="listing-featured-wrap" data-aos="fade-up">
                 <a href="<?php echo esc_url(get_the_permalink()); ?>">
                   <div class="listing-featured-wrap-image" style="background: url(<?php echo $thumbnail_url; ?>) no-repeat top;"></div></a>
@@ -452,7 +452,7 @@ get_header();
     <div class="container home-container">
       <h2 data-aos="fade-up"><?php echo wp_kses_post($cta_heading); ?></h2>
       <div class="btn-cta-wrap aos-init" data-aos="fade-up">
-        <a class="homeStartNowBtn" href="<?php echo esc_url($cta_button_link); ?>"><?php echo esc_html($cta_button_text); ?></a>
+        <a class="startNowBtn" href="<?php echo esc_url($cta_button_link); ?>"><?php echo esc_html($cta_button_text); ?></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Set has_archive = false, noticed styling conflicts came from https://github.com/DreamWay-Media/dwm-wp-theme/commit/f06c76327585c0407faeb5e6cd11984ac75fd5b2#diff-bd9c6c83001f3593781ba6aea9e087c561c07323d689978dddb4e31db37e060bL370 so had to make some fixes.

https://app.asana.com/0/599212887649773/1208631387212776/f