### PR TITLE
consistent h2 font size in HP - 50px

### DIFF
--- a/scss/pages/_home.scss
+++ b/scss/pages/_home.scss
@@ -102,7 +102,7 @@
   padding: 80px 0px;
 }
 .featured-blog-wrap h2 {
-  font-size: 48px;
+  font-size: 50px;
   font-weight: bold;
   margin-right: 120px;
   line-height: 52px;


### PR DESCRIPTION
Font size for h2's in HP are 50px
(Ticket link: https://app.asana.com/0/599212887649773/1208671919317072/f)